### PR TITLE
Add platform and wayland.libDecor init hints

### DIFF
--- a/core/src/main/kotlin/uno/glfw/InitHint.kt
+++ b/core/src/main/kotlin/uno/glfw/InitHint.kt
@@ -22,4 +22,22 @@ class InitHint {
             glfwInitHint(GLFW_COCOA_MENUBAR, value.i)
             field = value
         }
+
+    var platform: Int
+        get() = throw Exception("No getting allowed")
+        set(value) {
+            glfwInitHint(GLFW_PLATFORM, value)
+        }
+
+    val wayland = Wayland()
+    fun wayland(block: Wayland.() -> Unit) = wayland.block()
+
+    class Wayland {
+        var libDecor: Int
+            get() = throw Exception("No getting allowed")
+            set(value) {
+                glfwInitHint(GLFW_WAYLAND_LIBDECOR, value)
+            }
+    }
+
 }


### PR DESCRIPTION
I wanted to add platform hints to my code as follows

```kotlin
glfw {
    errorCB = defaultErrorCB

    initHint {
        if (glfw.Platform.Wayland.supported) {
            platform = GLFW_PLATFORM_WAYLAND
            libDecor = GLFW_WAYLAND_PREFER_LIBDECOR
        }
    }
```

I can do this with the extensions:
```kotlin
var InitHint.platform: Int
    get() = throw Exception("No getting allowed")
    set(value) {
        glfwInitHint(GLFW_PLATFORM, value)
    }

var InitHint.libDecor: Int
    get() = throw Exception("No getting allowed")
    set(value) {
        glfwInitHint(GLFW_WAYLAND_LIBDECOR, value)
    }
```

but I thought I'd also contribute them to your repository if you're willing to take them!

I've actually put the libDecor in its own "wayland" block within InitHints, so it reads like this for normal usage:

```kotlin
glfw {
    errorCB = defaultErrorCB

    initHint {
        if (glfw.Platform.Wayland.supported) {
            platform = GLFW_PLATFORM_WAYLAND
            wayland {
                libDecor = GLFW_WAYLAND_PREFER_LIBDECOR
            }
        }
    }
```

I was torn on a name for `platform`, as it's already a property name. I went with simplicity though as we're already in the InitHints block, but it could also be `platformHint`.

Additionally, I kept them as properties rather than functions, despite not being able to read the value, as I feel the syntax is nicer, i.e. `platform = GLFW_PLATFORM_XXX` rather than `platform(GLFW_PLATFORM_XXX)` as everything else is assigning rather than calling.